### PR TITLE
Update code.h

### DIFF
--- a/Level-2/code.h
+++ b/Level-2/code.h
@@ -46,7 +46,7 @@ bool update_setting(user_account* ua, const char *index, const char *value) {
     i = strtol(index, &endptr, 10);
     if (*endptr)
         return false;
-    if (i >= SETTINGS_COUNT)
+    if (i < 0 || i >= SETTINGS_COUNT)  // Reject negative and out-of-bounds indices
         return false;
     v = strtol(value, &endptr, 10);
     if (*endptr)


### PR DESCRIPTION
The code has a bug in the 'update_setting()' function that allows a user to supply a negative index which can result in writing to memory outside the bounds of the setting array.

We Can Fix This By Adding A Check To Ensures That The Index Is Non-Negative Before Attempting To Write To The Array. Adding If Statement at the beginning of 'update_setting()'

if (i < 0 || i >= SETTINGS_COUNT)
        return false;

### Why:

Closes [issue link]

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
