### PR TITLE
Re-order local installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Once installation has completed, clone your repository to your local machine and
 $ git clone https://github.com/YOUR-USERNAME/YOUR-REPOSITORY
 ```
 6. Press **Enter** to create your local clone.
-7. Install dependencies by running:
+7. Change the working directory to the cloned directory.
+8. Install dependencies by running:
 ```bash
 pip3 install -r requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ sudo apt-get install libldap2-dev libsasl2-dev
 ```bash
 sudo yum install python-devel openldap-devel
 ```
-- Then, for both Debian/Ubuntu and CentOS/RHEL, install `pyOpenSSL` by running:
+- For Archlinux, run: 
+```bash
+sudo pacman -Sy libldap libsasl
+```
+- Then, for any of the above Linux distribution install `pyOpenSSL` by running:
 ```bash
 pip3 install pyOpenSSL
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ sudo apt-get install libldap2-dev libsasl2-dev
 ```bash
 sudo yum install python-devel openldap-devel
 ```
+- Then, for both Debian/Ubuntu and CentOS/RHEL, install `pyOpenSSL` by running:
+```bash
+pip3 install pyOpenSSL
+```
 
 Once installation has completed, clone your repository to your local machine and install required dependencies.
 1. From your repository, click the **Code** drop down button in the upper-right of your repository navigation bar.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sudo yum install python-devel openldap-devel
 ```bash
 sudo pacman -Sy libldap libsasl
 ```
-- Then, for any of the above Linux distribution install `pyOpenSSL` by running:
+- Then, for any of the above Linux distributions install `pyOpenSSL` by running:
 ```bash
 pip3 install pyOpenSSL
 ```

--- a/README.md
+++ b/README.md
@@ -52,16 +52,8 @@ sudo apt-get install libldap2-dev libsasl2-dev
 ```bash
 sudo yum install python-devel openldap-devel
 ```
-- Then, for both Debian/Ubuntu and CentOS/RHEL, install `pyOpenSSL` by running:
-```bash
-pip3 install pyOpenSSL
-```
-3. Install the other dependencies by running:
-```bash
-pip3 install -r requirements.txt
-```
 
-Once installation has completed, clone your repository to your local machine.
+Once installation has completed, clone your repository to your local machine and install required dependencies.
 1. From your repository, click the **Code** drop down button in the upper-right of your repository navigation bar.
 1. Select the `Local` tab from the menu.
 1. Copy your preferred URL.
@@ -71,6 +63,10 @@ Once installation has completed, clone your repository to your local machine.
 $ git clone https://github.com/YOUR-USERNAME/YOUR-REPOSITORY
 ```
 6. Press **Enter** to create your local clone.
+7. Install dependencies by running:
+```bash
+pip3 install -r requirements.txt
+```
 
 For more information about cloning repositories, see "[Cloning a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)."
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sudo yum install python-devel openldap-devel
 ```bash
 sudo pacman -Sy libldap libsasl
 ```
-- Then, for any of the above Linux distributions install `pyOpenSSL` by running:
+- Then, for all of the above Linux distributions install `pyOpenSSL` by running:
 ```bash
 pip3 install pyOpenSSL
 ```


### PR DESCRIPTION
### Why:

The dependencies installation instruction using `requirements.txt` is before cloning the repository, which should be after.

### What's being changed:

The dependencies installation step is moved just after repository cloning. The explicit installation instruction for `pyOpenSSL` dependency is removed since it exists in `requirements.txt`.

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
