### PR TITLE
Fix Typos

### DIFF
--- a/Level-2/solution.c
+++ b/Level-2/solution.c
@@ -54,7 +54,7 @@ bool update_setting(user_account* ua, const char *index, const char *value) {
 }
 
 /*
-Buffer Overflow Vulnerabilty
+Buffer Overflow Vulnerability
 
 In hack.c, an attacker escalated privileges and became an admin by abusing 
 the fact that the code wasn't checking for negative index values.

--- a/Level-3/code.py
+++ b/Level-3/code.py
@@ -47,5 +47,5 @@ class TaxPayer:
         with open(path, 'rb') as form:
             tax_data = bytearray(form.read())
 
-        # assume that taxa data is returned on screen after this
+        # assume that tax data is returned on screen after this
         return path

--- a/Level-4/code.py
+++ b/Level-4/code.py
@@ -43,7 +43,7 @@ class Create(object):
                 WHERE type='table'AND name='stocks';
                 ''').fetchall()
  
-            # if tables do not exist, create them to instert dummy data
+            # if tables do not exist, create them and insert dummy data
             if table_fetch == []:
                 cur.execute(
                     '''

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The following local installation guide is adapted to Debian/Ubuntu and CentOS/RH
 ```bash
 uname -a
 ```
- - For Debian/Ubuntu, run:
- ```bash
+- For Debian/Ubuntu, run:
+```bash
 sudo apt-get update
 sudo apt-get install libldap2-dev libsasl2-dev
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ At the time "The Matrix" was first released in 1999, programming was different. 
 ### :keyboard: What's in the repo?
 For each level, you will find the same file structure:
 - `code` includes the vulnerable code to be reviewed
-- `hack` exploits the vulnerabilities in `code`. Running `hack.py` will fail initially, your goal is to get this file to pass.
+- `hack` exploits the vulnerabilities in `code`. Running `hack.c` will fail initially, your goal is to get this file to pass.
 - `hint` offers a hint if you get stuck.
 - `solution` provides one working solution. There are several possible solutions.
 - `tests` contains the unit tests that should still pass after you have implemented your fix.


### PR DESCRIPTION
### Why:

Fixes a few typos and misspellings.

### What's being changed:

- 536e8a1aab42355c2fecfa42e08b9eb1af330542 fix spelling of vulnerability
- 389881a7e3ce649cc1217a4200644cd477038324 fix typo 'taxa' to tax
- 33b3ff38b8a33f6214a5779cebe7ddb0be67754a fix spelling of insert and improve grammar
- fb5fc0f311391571db57dfcd9321c595d3d538aa update Level 2 "What's in the repo" to reference c code instead of python
- 118c803249e463673679fd5acd8a6847ca9005a8 remove inconsistent leading whitespace from "Local installation" block in README

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
