### PR TITLE
Fix: Remove an unintended way to win level one

### DIFF
--- a/Level-1/hack.py
+++ b/Level-1/hack.py
@@ -4,20 +4,21 @@ import code as c
 class TestOnlineStore(unittest.TestCase):
 
     # Tricks the system and walks away with 1 television, despite valid payment & reimbursement
-    def test_4(self):
+    def test_5(self):
         tv = c.Item(type='product', description='tv', amount=1000.00, quantity=1)
-        payment = c.Item(type='payment', description='invoice_4', amount=1e19, quantity=1)
-        reimbursement = c.Item(type='payment', description='reimbursement_4', amount=-1e19, quantity=1)
-        order_4 = c.Order(id='4', items=[payment, tv, reimbursement])
-        self.assertEqual(c.validorder(order_4), 'Order ID: 4 - Payment imbalance: $-1000.00')
+        payment = c.Item(type='payment', description='invoice_5', amount=1e19, quantity=1)
+        reimbursement = c.Item(type='payment', description='reimbursement_5', amount=-1e19, quantity=1)
+        order_5 = c.Order(id='5', items=[payment, tv, reimbursement])
+        self.assertEqual(c.validorder(order_5), 'Order ID: 5 - Payment imbalance: $-1000.00')
 
     # Valid payments that should add up correctly, but do not
-    def test_5(self):
+    def test_6(self):
         small_item = c.Item(type='product', description='accessory', amount=3.3, quantity=1)
-        payment_1 = c.Item(type='payment', description='invoice_5_1', amount=1.1, quantity=1)
-        payment_2 = c.Item(type='payment', description='invoice_5_2', amount=2.2, quantity=1)
-        order_5 = c.Order(id='5', items=[small_item, payment_1, payment_2])
-        self.assertEqual(c.validorder(order_5), 'Order ID: 5 - Full payment received!')
+        payment_1 = c.Item(type='payment', description='invoice_6_1', amount=1.1, quantity=1)
+        payment_2 = c.Item(type='payment', description='invoice_6_2', amount=2.2, quantity=1)
+        order_6 = c.Order(id='6', items=[small_item, payment_1, payment_2])
+        self.assertEqual(c.validorder(order_6),'Order ID: 6 - Full payment received!')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Level-1/tests.py
+++ b/Level-1/tests.py
@@ -24,10 +24,10 @@ class TestOnlineStore(unittest.TestCase):
         order_3 = c.Order(id='3', items=[payment, tv, reimbursement])
         self.assertEqual(c.validorder(order_3),'Order ID: 3 - Payment imbalance: $-1000.00')
 
-     # Example 3 - successfully handles decimal places correctly
+    # Example 4 - successfully handles decimal places
     def test_4(self):
-        tv = c.Item(type='product', description='candy bar',amount=5.99, quantity=1)
-        order_4 = c.Order(id='4', items=[tv])
+        smaller_item = c.Item(type='product', description='cable',amount=5.99, quantity=1)
+        order_4 = c.Order(id='4', items=[smaller_item])
         self.assertEqual(c.validorder(order_4),'Order ID: 4 - Payment imbalance: $-5.99')
 
 if __name__ == '__main__':

--- a/Level-1/tests.py
+++ b/Level-1/tests.py
@@ -8,21 +8,27 @@ class TestOnlineStore(unittest.TestCase):
         tv = c.Item(type='product', description='tv', amount=1000.00, quantity=1)
         payment = c.Item(type='payment', description='invoice_1', amount=1000.00, quantity=1)
         order_1 = c.Order(id='1', items=[payment, tv])
-        self.assertEqual(c.validorder(order_1), 'Order ID: 1 - Full payment received!')
+        self.assertEqual(c.validorder(order_1),'Order ID: 1 - Full payment received!')
 
     # Example 2 - successfully detects payment imbalance as tv was never paid
     def test_2(self):
-        tv = c.Item(type='product', description='tv', amount=1000.00, quantity=1)
+        tv = c.Item(type='product', description='tv',amount=1000.00, quantity=1)
         order_2 = c.Order(id='2', items=[tv])
-        self.assertEqual(c.validorder(order_2), 'Order ID: 2 - Payment imbalance: $-1000.00')
+        self.assertEqual(c.validorder(order_2),'Order ID: 2 - Payment imbalance: $-1000.00')
 
     # Example 3 - successfully reimburses client for a tv they have returned so payment imbalance exists
     def test_3(self):
-        tv = c.Item(type='product', description='tv', amount=1000.00, quantity=1)
-        payment = c.Item(type='payment', description='invoice_3', amount=1000.00, quantity=1)
+        tv = c.Item(type='product', description='tv',amount=1000.00, quantity=1)
+        payment = c.Item(type='payment', description='invoice_3',amount=1000.00, quantity=1)
         reimbursement = c.Item(type='payment', description='reimbursement_3', amount=-1000.00, quantity=1)
         order_3 = c.Order(id='3', items=[payment, tv, reimbursement])
-        self.assertEqual(c.validorder(order_3), 'Order ID: 3 - Payment imbalance: $-1000.00')
+        self.assertEqual(c.validorder(order_3),'Order ID: 3 - Payment imbalance: $-1000.00')
+
+     # Example 3 - successfully handles decimal places correctly
+    def test_4(self):
+        tv = c.Item(type='product', description='candy bar',amount=5.99, quantity=1)
+        order_4 = c.Order(id='4', items=[tv])
+        self.assertEqual(c.validorder(order_4),'Order ID: 4 - Payment imbalance: $-5.99')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary

By casting all the numbers to integers , Level One's challenge can be won since the `int` data can grow and expand to handle pretty much any whole number thrown at it. Decimal places get forgotten. As the challenge is dealing with a store, that shouldn't be allowed. 

Closes #43 

### Changes

This introduces an additional test to ensure cents aren't just deleted by the Python program and renumbers existing tests to match the count. 

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
