### PR TITLE
Add Lua level: Metatable Hooks (revives #128 by @TheDarkThief)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,14 +8,15 @@
         "ms-vscode.cpptools-extension-pack",
         "redhat.vscode-yaml",
         "golang.go",
-        "vitest.explorer"
+        "vitest.explorer",
+        "sumneko.lua"
       ],
       "settings": {
         "vitest.logLevel": "error"
       }
     }
   },
-  "postCreateCommand": "pip install --break-system-packages -r requirements.txt; npm install --prefix Season-3/; npm install --prefix Season-4/; chmod +x Season-4/bin/prodbot.js && mkdir -p ~/.local/bin && ln -sf \"$(pwd)/Season-4/bin/prodbot.js\" ~/.local/bin/prodbot && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc && export PATH=\"$HOME/.local/bin:$PATH\"",
+  "postCreateCommand": "pip install --break-system-packages -r requirements.txt; npm install --prefix Season-3/; npm install --prefix Season-4/; chmod +x Season-4/bin/prodbot.js && mkdir -p ~/.local/bin && ln -sf \"$(pwd)/Season-4/bin/prodbot.js\" ~/.local/bin/prodbot && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc && export PATH=\"$HOME/.local/bin:$PATH\"; sudo apt-get update && sudo apt-get install -y lua5.4 luarocks && sudo luarocks install busted",
   "features": {
     "ghcr.io/devcontainers/features/python:1.7.1": {},
     "ghcr.io/devcontainers/features/node:1": {}

--- a/Bonus-Levels/Lua-Metatable-Hooks/README.md
+++ b/Bonus-Levels/Lua-Metatable-Hooks/README.md
@@ -1,0 +1,63 @@
+# Bonus Level: Lua Metatable Hooks — "That's not a Billboard"
+
+_A community-contributed bonus level._ 🤖
+
+Languages: `Lua`
+
+> This level lives in `Bonus-Levels/` rather than a numbered Season because it is a
+> standalone Lua challenge and does not belong to any Season's storyline. It was
+> originally proposed for the upstream repository in
+> [skills/secure-code-game#128](https://github.com/skills/secure-code-game/pull/128).
+
+### 🚀 Credits
+
+The author of this level is Abdullah [@TheDarkThief](https://github.com/TheDarkThief).
+
+You can be next! We welcome contributions for new game levels! Learn more [here](https://github.com/skills/secure-code-game/blob/main/CONTRIBUTING.md).
+
+### 📝 Storyline
+
+Your company sells low-powered E-ink displays powered by a small embedded system; they are called E-Boards. Because they are so weak, they send a request to the server with the RSS feeds the user has configured; the server proceeds to generate a bitmap image and returns the request to the board, which will eventually display the images to the user. No one will abuse this right? Do you have what it takes to fix the bug?
+
+### ⌨️ What's in the folder?
+
+- `code.lua` includes the vulnerable code to be reviewed.
+- `hack.lua` exploits the vulnerabilities in `code.lua`. Running `hack.lua` will fail initially; your goal is to get this file to pass.
+- `tests.lua` contains the unit tests that should still pass after you have implemented your fix.
+- `hint.txt` offers guidance if you get stuck.
+- `solution/` offers a working solution. Remember, there are several possible solutions.
+
+### ✅ Requirements
+
+This level uses [Lua](https://www.lua.org/) and the [busted](https://lunarmodules.github.io/busted/) test framework.
+
+```bash
+# Debian/Ubuntu (or a GitHub Codespace on this repo)
+sudo apt-get update && sudo apt-get -y install lua5.4 luarocks
+sudo luarocks install busted
+
+# macOS (Homebrew)
+brew install lua luarocks && luarocks install busted
+```
+
+### 🚦 Time to start!
+
+1. Review the code in `code.lua`. Can you spot the bug(s)?
+1. Try to fix the bug. Ensure that unit tests are still passing 🟢.
+
+   ```bash
+   (cd Bonus-Levels/Lua-Metatable-Hooks/ && busted tests.lua)
+   ```
+1. You successfully completed the level when both `hack.lua` and `tests.lua` pass 🟢.
+
+   ```bash
+   (cd Bonus-Levels/Lua-Metatable-Hooks/ && busted hack.lua)
+   ```
+1. If you get stuck, read `hint.txt` and try again.
+1. Compare your solution with `solution/solution.lua`; remember there are multiple solutions.
+
+   ```bash
+   (cd Bonus-Levels/Lua-Metatable-Hooks/solution && busted solution_test.lua)
+   ```
+
+If you need assistance, don't hesitate to ask for help in the upstream [GitHub Discussions](https://github.com/skills/secure-code-game/discussions).

--- a/Bonus-Levels/Lua-Metatable-Hooks/code.lua
+++ b/Bonus-Levels/Lua-Metatable-Hooks/code.lua
@@ -1,0 +1,42 @@
+-- Welcome to Secure Code Game — Bonus Level: Lua Metatable Hooks!
+
+-- Follow the instructions below to get started:
+
+-- 1. tests.lua is passing but the code is vulnerable
+-- 2. Review the code. Can you spot the bugs(s)?
+-- 3. Fix the code.lua, but ensure that tests.lua passes
+-- 4. Run hack.lua and if passing then CONGRATS!
+-- 5. If stuck then read the hint
+-- 6. Compare your solution with solution/solution.lua
+
+local module = {}
+
+
+--- Given a request table with empty image entries it should populate it with bitmap images
+--- Currently uses a placeholder of 'PLACEHOLDER IMAGE'
+--- @param request table: The request table which we will populate with images
+--- @return string|table: Of the sources now with the generated bitmaps to display
+module.generate_bmps = function(request)
+    -- Do not delete example SHA1 hash
+    local secret_key = "fb2f85c88567f3c8ce9b799c7c54642d0c7b41f6"
+    -- End of do not delete
+
+    if type(request) ~= "table" then
+        return "Invalid request"
+    end
+    for i = 1, #request, 1 do
+        if type(request[i].source) ~= "string" then
+            --[[ If the user provides us with a bad entry, set the returned image to an error message.
+                 Letting the user know something is wrong --]]
+            request[i] = { source = "Bad request", image = "ERROR IMAGE" }
+        else
+            -- This is a placeholder for a bitmap blob generator
+            request[i].image = "PLACEHOLDER IMAGE"
+        end
+    end
+    return request
+end
+
+
+
+return module

--- a/Bonus-Levels/Lua-Metatable-Hooks/hack.lua
+++ b/Bonus-Levels/Lua-Metatable-Hooks/hack.lua
@@ -1,0 +1,59 @@
+-- This file exploits the vulnerabilities in code. Running this file will fail initially
+-- (it contains failing tests). As all other levels, your goal is to get this file to pass.
+
+-- Run them by opening a terminal and running the following:
+-- $ (cd Bonus-Levels/Lua-Metatable-Hooks/ && lua hack.lua)
+
+require 'busted.runner' ()
+
+local code = require("code")
+
+
+--- This function sends a malicous request, and returns
+--- the result given by the code.
+--- @return table | string: the resulting response
+local index_hook_exploit = function()
+    local malicous_metatable = {
+        __metatable = {},
+        __index = function(original_table, index)
+            print("[SCRIPT EXECUTING]")
+            local variables = {}
+            local varIndex = 1
+            while true do
+                -- extracts a local variables down 2 from the call stack
+                local extractedVarIndex, extractedVal = debug.getlocal(2, varIndex)
+                if extractedVarIndex ~= nil then
+                    variables[extractedVarIndex] = extractedVal
+                else
+                    break
+                end
+                varIndex = 1 + varIndex
+            end
+
+            original_table.success = false
+            original_table.recieving_payload = variables["secret_key"]
+
+            return "Hook executed"
+        end
+    }
+
+    -- Requests shouldn't have nil values but nothing about this table is malicous
+    local odd_request = { { source = "Link 1", image = nil }, nil, { source = "Link 2", image = nil } }
+
+    -- We exploit the fact that when you try to index a nil value in a table the metatable will be called
+    local malicous_request = setmetatable(odd_request, malicous_metatable)
+    local result = code.generate_bmps(malicous_request)
+
+    if type(result) == "table" and result.recieving_payload ~= nil then
+        print("Malicous payload recieved: ", result.recieving_payload)
+    end
+
+    return result
+end
+
+
+describe("Does it reject a table with hooks", function()
+    it("it should give us a 'Invalid request'", function()
+        assert.are.equals("Invalid request", index_hook_exploit())
+    end)
+end)

--- a/Bonus-Levels/Lua-Metatable-Hooks/hint.txt
+++ b/Bonus-Levels/Lua-Metatable-Hooks/hint.txt
@@ -1,0 +1,3 @@
+Seems like this has to do with a particualarity of how Lua handles indexing a table.
+What is hack.lua doing to enable it to run the code?
+Maybe we should read the docs about tables: https://www.lua.org/manual/5.3/manual.html#2.1 or https://www.luadocs.com/docs/functions/table

--- a/Bonus-Levels/Lua-Metatable-Hooks/solution/solution.lua
+++ b/Bonus-Levels/Lua-Metatable-Hooks/solution/solution.lua
@@ -1,0 +1,61 @@
+--[[Attempt to sanitize the request by calling setmetatable on it
+    We know that if the __metatable property is set setmetatable will throw an exception
+    thus why we make a protected call, and if it succeeds we can continue.
+    If it fails we know someone is trying to do a metatable exploit.
+--]]
+
+
+-- Full solution:
+
+local module = {}
+
+--- Given a request table with empty image entries it should populate it with bitmap images
+--- Currently uses a placeholder of 'PLACEHOLDER IMAGE'
+--- @param request table: The request table which we will populate with images
+--- @return string|table: Of the sources now with the generated bitmaps to display
+module.generate_bmps = function(request)
+    -- Do not delete example SHA1 hash
+    local secret_key = "fb2f85c88567f3c8ce9b799c7c54642d0c7b41f6"
+    -- End of do not delete
+
+    if type(request) ~= "table" then
+        return "Invalid request"
+    end
+
+    --[[ Sanitizes the root table by setting the metatable; if it throws an exception
+        __metatable was set meaning someone is activly trying to do a metatable hook exploit
+    --]]
+    local isNotMalicous, errVal = pcall(function()
+        setmetatable(request, {})
+    end)
+
+    if not isNotMalicous then
+        return "Invalid request"
+    end
+    -- end of first sanitization
+
+    for i = 1, #request, 1 do
+        -- Sanitizes subtables
+        local isNotMalicous, errVal = pcall(function()
+            setmetatable(request[i], {})
+        end)
+
+        if not isNotMalicous then
+            return "Invalid request"
+        end
+
+        if type(request[i].source) ~= "string" then
+            --[[ If the user provides us with a bad entry, set the returned image to an error message.
+                 Letting the user know something is wrong --]]
+            request[i] = { source = "Bad request", image = "ERROR IMAGE" }
+        else
+            -- This is a placeholder for a bitmap blob generator
+            request[i].image = "PLACEHOLDER IMAGE"
+        end
+    end
+    return request
+end
+
+
+
+return module

--- a/Bonus-Levels/Lua-Metatable-Hooks/solution/solution_test.lua
+++ b/Bonus-Levels/Lua-Metatable-Hooks/solution/solution_test.lua
@@ -1,0 +1,112 @@
+-- Run solution_test.lua by following the instructions below:
+
+-- This file is a copy of tests.lua and hack.lua
+-- It tests the solution for failing and passing payloads
+-- This file should always pass as it is testing the solution
+
+-- Run them by opening a terminal and running the following:
+-- $ (cd Bonus-Levels/Lua-Metatable-Hooks/solution && lua solution_test.lua)
+
+require 'busted.runner' ()
+local code = require("solution")
+
+
+--- This function sends a malicous request, and returns
+--- the result given by the code.
+--- @return table | string: the resulting response
+local index_hook_exploit = function()
+    local malicous_metatable = {
+        __metatable = {},
+        __index = function(original_table, index)
+            print("[SCRIPT EXECUTING]")
+            local variables = {}
+            local varIndex = 1
+            while true do
+                -- extracts a local variables down 2 from the call stack
+                local extractedVarIndex, extractedVal = debug.getlocal(2, varIndex)
+                if extractedVarIndex ~= nil then
+                    variables[extractedVarIndex] = extractedVal
+                else
+                    break
+                end
+                varIndex = 1 + varIndex
+            end
+
+            original_table.success = false
+            original_table.recieving_payload = variables["secret_key"]
+
+            return "Hook executed"
+        end
+    }
+
+    -- Requests shouldn't have nil values but nothing about this table is malicous
+    local odd_request = { { source = "Link 1", image = nil }, nil, { source = "Link 2", image = nil } }
+
+    -- We exploit the fact that when you try to index a nil value in a table the metatable will be called
+    local malicous_request = setmetatable(odd_request, malicous_metatable)
+    local result = code.generate_bmps(malicous_request)
+
+    if type(result) == "table" and result.recieving_payload ~= nil then
+        print("Malicous payload recieved: ", result.recieving_payload)
+    end
+
+    return result
+end
+
+
+-- Given a normal request does it return the proper placeholder image
+local does_it_handle_requests = function()
+    local our_normal_request = {
+        { source = "Link 1", image = nil },
+        { source = "Link 2", image = nil },
+        { source = "Link 3", image = nil }
+    }
+
+    local result = code.generate_bmps(our_normal_request)
+
+    return result
+end
+
+
+-- Given a malformed request does it handle it gracefully
+local does_it_hanlde_malformed_requests = function()
+    local our_normal_request = {
+        { source = "Link 1", image = nil },
+        { source = 1,        image = nil },
+        { source = "Link 3", image = nil }
+    }
+
+
+
+    local result = code.generate_bmps(our_normal_request)
+
+    return result
+end
+
+describe("Does it handle requests properly", function()
+    it("should return a populated table", function()
+        local expected_result = {
+            { source = "Link 1", image = "PLACEHOLDER IMAGE" },
+            { source = "Link 2", image = "PLACEHOLDER IMAGE" },
+            { source = "Link 3", image = "PLACEHOLDER IMAGE" }
+        }
+        assert.are.same(expected_result, does_it_handle_requests())
+    end)
+end)
+
+describe("Does it handle malformed requests properly", function()
+    it("should return a populated table with a bad image entry", function()
+        local expected_result = {
+            { source = "Link 1",      image = "PLACEHOLDER IMAGE" },
+            { source = "Bad request", image = "ERROR IMAGE" },
+            { source = "Link 3",      image = "PLACEHOLDER IMAGE" }
+        }
+        assert.are.same(expected_result, does_it_hanlde_malformed_requests())
+    end)
+end)
+
+describe("Does it reject a table with hooks", function()
+    it("it should give us a 'Invalid request'", function()
+        assert.are.equals("Invalid request", index_hook_exploit())
+    end)
+end)

--- a/Bonus-Levels/Lua-Metatable-Hooks/tests.lua
+++ b/Bonus-Levels/Lua-Metatable-Hooks/tests.lua
@@ -1,0 +1,59 @@
+-- This file contains passing tests.
+
+-- Run them by opening a terminal and running the following:
+-- $ (cd Bonus-Levels/Lua-Metatable-Hooks/ && lua tests.lua)
+
+require 'busted.runner' ()
+local code = require("code")
+
+
+-- Given a normal request does it return the proper placeholder image
+local does_it_handle_requests = function()
+    local our_normal_request = {
+        { source = "Link 1", image = nil },
+        { source = "Link 2", image = nil },
+        { source = "Link 3", image = nil }
+    }
+
+    local result = code.generate_bmps(our_normal_request)
+
+    return result
+end
+
+
+-- Given a malformed request does it handle it gracefully
+local does_it_hanlde_malformed_requests = function()
+    local our_normal_request = {
+        { source = "Link 1", image = nil },
+        { source = 1,        image = nil },
+        { source = "Link 3", image = nil }
+    }
+
+
+
+    local result = code.generate_bmps(our_normal_request)
+
+    return result
+end
+
+describe("Does it handle requests properly", function()
+    it("should return a populated table", function()
+        local expected_result = {
+            { source = "Link 1", image = "PLACEHOLDER IMAGE" },
+            { source = "Link 2", image = "PLACEHOLDER IMAGE" },
+            { source = "Link 3", image = "PLACEHOLDER IMAGE" }
+        }
+        assert.are.same(expected_result, does_it_handle_requests())
+    end)
+end)
+
+describe("Does it handle malformed requests properly", function()
+    it("should return a populated table with a bad image entry", function()
+        local expected_result = {
+            { source = "Link 1",      image = "PLACEHOLDER IMAGE" },
+            { source = "Bad request", image = "ERROR IMAGE" },
+            { source = "Link 3",      image = "PLACEHOLDER IMAGE" }
+        }
+        assert.are.same(expected_result, does_it_hanlde_malformed_requests())
+    end)
+end)


### PR DESCRIPTION
This revives the Lua metatable `__index` hook level from #128 by @TheDarkThief, which `@jkcso` reviewed and wanted to accept but which has since gone stale and now conflicts with the current Season 4.

All credit for the level goes to @TheDarkThief — the commit is authored under their name and the content is unchanged apart from the re-homing described below.

### What changed vs #128
- **Re-homed to `Bonus-Levels/Lua-Metatable-Hooks/`** instead of `Season-4/Level-1/`. When #128 was opened, Season 4 did not exist; `main` now has the full ProdBot Season 4, so the original path collides (add/add on `Season-4/README.md`, `.devcontainer/devcontainer.json`). A standalone folder keeps the ProdBot narrative intact and resolves all conflicts.
- **Dropped #128s `.devcontainer` / `codeql-analysis.yml` edits**, which had become stale rollbacks (they removed the current ProdBot setup and downgraded `actions/checkout@v7`→`v4`, `codeql-action@v4.37.3`→`v3`). Instead this only *appends* `lua5.4` + `luarocks` + `busted` and the `sumneko.lua` extension to the existing devcontainer.
- Updated in-file path references and added a self-contained `README.md`.

### The level
A Lua metatable `__index` hook that exfiltrates a local (`secret_key`) via `debug.getlocal` when the vulnerable code indexes a table with `nil` gaps. The fix sanitizes untrusted tables with a `pcall(setmetatable, t, {})` guard (a set `__metatable` throws, revealing the hook).

### Tests (busted)
- `tests.lua` → 2/2 pass
- `solution/solution_test.lua` → 3/3 pass
- `hack.lua` fails against the vulnerable `code.lua` by design (that failing exploit test is the challenge)

### On process & placement
I know `CONTRIBUTING.md` asks for a Discussions proposal first — I opened this as a PR because the level was already maintainer-reviewed in #128. Happy to move it to a New Level Proposal discussion, and happy to relocate it (e.g. a numbered Season slot) if you prefer a different home. Also glad to close this in favour of @TheDarkThief updating #128 directly if that is the maintainers' preference.